### PR TITLE
Update httparty dependency to mitigate vulnerability

### DIFF
--- a/exception_notification_telegram.gemspec
+++ b/exception_notification_telegram.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.8"
 
   spec.add_dependency "exception_notification", "~> 4.4"
-  spec.add_dependency "httparty", "~> 0.20.0"
+  spec.add_dependency "httparty", "~> 0.21.0"
 end


### PR DESCRIPTION
I have updated httparty from 0.20.0 to 0.21.0 to mitigate a vulnerability [1] & [2] and satisfy bundler-audit [3].

I did not create a new release (update `version.rb` & `bundle exec rake release`), as I suspect this would have to be done by the owner.

I have run the tests with `bundle exec rake spec` and I have successfully tested it in my rails app with `gem 'exception_notification_telegram', path: '../exception_notification_telegram'` and an exception.

May I ask the owner to release a new version? Thank you very much.

Let me know if I made any mistakes as this is my first pull request.


[1] https://github.com/jnunemaker/httparty/security/advisories/GHSA-5pq7-52mg-hr42
[2] https://github.com/advisories/GHSA-5pq7-52mg-hr42
[3] https://github.com/rubysec/bundler-audit